### PR TITLE
refactor: remove client directives from components

### DIFF
--- a/src/components/Consultation/index.tsx
+++ b/src/components/Consultation/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { WhatsappLogo } from '@phosphor-icons/react';
 
 export default function Consultation() {

--- a/src/components/Missions/index.tsx
+++ b/src/components/Missions/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { NotePencil, Stethoscope, VideoCamera } from '@phosphor-icons/react';
 
 export default function Services() {

--- a/src/components/NutriSection/index.tsx
+++ b/src/components/NutriSection/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { WhatsappLogo } from '@phosphor-icons/react';
 import Image from 'next/image';
 


### PR DESCRIPTION
## Summary
- remove `use client` directive from `NutriSection`, `Consultation` and `Missions` components to render them on the server
- ensure Phosphor icons render correctly in a server environment using `react-dom/server`

## Testing
- `npm test` (fails: Missing script: "test")
- `node --input-type=module ...` (renders `WhatsappLogo`, `NotePencil`, `Stethoscope`, `VideoCamera` to SVG)


------
https://chatgpt.com/codex/tasks/task_e_689c4a426bfc8323a3d35832fdfd25fe