### PR TITLE
fix: add noopener noreferrer to external links

### DIFF
--- a/src/components/Consultation/index.tsx
+++ b/src/components/Consultation/index.tsx
@@ -36,6 +36,7 @@ export default function Consultation() {
           <a
             href="https://wa.me/819038354891"
             target="_blank"
+            rel="noopener noreferrer"
             className="flex justify-center items-center bg-gradient-to-r from-murasaki300 to-murasaki100 text-white font-bold px-8 py-4 rounded shadow-lg hover:opacity-90 transition"
           >
             <WhatsappLogo size={30} className="inline mr-3" />

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -48,6 +48,7 @@ function Header() {
               key={desktop.href}
               href={desktop.href}
               target={desktop.external ? '_blank' : '_self'}
+              rel={desktop.external ? 'noopener noreferrer' : undefined}
               className="text-base font-semibold text-gray-800 hover hover:text-murasaki200"
             >
               {desktop.label}
@@ -65,6 +66,7 @@ function Header() {
                 key={mobile.href}
                 href={mobile.href}
                 target={mobile.external ? '_blank' : '_self'}
+                rel={mobile.external ? 'noopener noreferrer' : undefined}
                 className="text-lg font-semibold text-gray-800"
                 onClick={() => setIsOpen(false)}
               >

--- a/src/components/NutriSection/index.tsx
+++ b/src/components/NutriSection/index.tsx
@@ -36,6 +36,7 @@ export default function NutriSection() {
             <a
               href="https://wa.me/819038354891"
               target="_blank"
+              rel="noopener noreferrer"
               // className="bg-murasaki300 text-white font-bold px-8 py-4 rounded shadow-lg hover:bg-murasaki100 transition"
               className="bg-gradient-to-r from-murasaki300 to-murasaki100 text-white font-bold px-8 py-4 rounded shadow-lg hover:opacity-90 transition"
             >


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to WhatsApp and navigation links that open in new tabs

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint src/components/Header/index.tsx src/components/NutriSection/index.tsx src/components/Consultation/index.tsx` (fails: ESLint couldn't find a configuration file)

------
https://chatgpt.com/codex/tasks/task_e_689c4a50e24c8323b082f4aab64c669d