### PR TITLE
chore: add npm auth token config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+always-auth=true
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Summary
- add .npmrc with registry and auth token placeholder

## Testing
- `pnpm config get registry`
- `pnpm login --registry https://registry.npmjs.org/` (fails: 403 Forbidden)
- `pnpm install --frozen-lockfile`
- `NPM_TOKEN=dummytoken pnpm install --frozen-lockfile`


------
https://chatgpt.com/codex/tasks/task_e_689c67c4f7688323ba6bad7be4ab34f8