### PR TITLE
Add Next.js build and start scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Site da nutricionista Rosemary Azuma",
   "scripts": {
     "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
     "prepare": "husky",
     "commit": "cz"
   },


### PR DESCRIPTION
## Summary
- add `build` and `start` scripts to package.json for Next.js

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch font `Inter`; Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c76a5bff4832394ff28266379b294